### PR TITLE
fix(character): render additional score descriptions via RichText

### DIFF
--- a/src/app/components/character/sections/scores/AdditionalScores.tsx
+++ b/src/app/components/character/sections/scores/AdditionalScores.tsx
@@ -4,6 +4,7 @@ import { useAppSelector, useAppDispatch } from '@/lib/hooks'
 import { initAdditionalScores, setAdditionalScores } from "@/lib/slices/characterSlice";
 import ExternalLink from '@/app/components/common/ExternalLink';
 import type { NormedAdditionalScore } from '@/lib/character-types';
+import { RichText } from '@/app/components/common/RichText';
 
 const AdditionalScores = ({
 		additionalScores
@@ -120,7 +121,7 @@ const AdditionalScores = ({
 									{s.title}
 								</div>
 								<div className="w-1/2 text-md align-top pl-0 align-top">
-									{s.description}
+									<RichText content={s.description} />
 								</div>
 								<div className="w-16 text-md text-base pl-0 flex justify-end">
 									{s.value}


### PR DESCRIPTION
AdditionalScores.description is a Lexical richText field in Payload; rendering it directly caused the same "object with keys {root}" React error as the technique descriptions fix.