### PR TITLE
fix: add Payload RootLayout to admin layout to establish ConfigProvid…

### DIFF
--- a/src/app/(payload)/layout.tsx
+++ b/src/app/(payload)/layout.tsx
@@ -1,5 +1,22 @@
+import type { ServerFunctionClient } from 'payload'
+import config from '@payload-config'
+import { RootLayout, handleServerFunctions } from '@payloadcms/next/layouts'
+import { importMap } from './admin/importMap'
 import React from 'react'
 
-export default function PayloadLayout({ children }: { children: React.ReactNode }) {
-  return children
+export default async function PayloadLayout({ children }: { children: React.ReactNode }) {
+  const serverFunction: ServerFunctionClient = async (args) => {
+    'use server'
+    return handleServerFunctions({
+      ...args,
+      config,
+      importMap,
+    })
+  }
+
+  return (
+    <RootLayout config={config} importMap={importMap} serverFunction={serverFunction}>
+      {children}
+    </RootLayout>
+  )
 }


### PR DESCRIPTION
…er tree

The admin layout was a bare pass-through, so PageConfigProvider in RootPage had no parent ConfigProvider above it, causing:
  TypeError: Cannot destructure property 'config' from null or undefined

RootLayout from @payloadcms/next/layouts wraps children in RootProvider (which includes ConfigProvider), the correct root for the Payload admin.