### PR TITLE
fix: exclude Payload MCP plugin from Next.js bundling

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,7 @@ const withSerwist = withSerwistInit({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  serverExternalPackages: ['@payloadcms/plugin-mcp', 'mcp-handler', '@modelcontextprotocol/sdk'],
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
@payloadcms/plugin-mcp uses new Function('z', ...) to evaluate Zod schemas at runtime. When webpack bundles the package it deduplicates Zod (resolving to v4 from @serwist/next) and strips Zod v3 internals, causing schema conversion to fall back to z.record(z.any()) which then throws "partial is not a function" when update tools try to call it.

serverExternalPackages keeps these packages unbundled so they use their own nested Zod v3 via native Node.js module resolution at runtime.