### PR TITLE
fix: pass slug args to REST_POST handler in dedicated MCP route

### DIFF
--- a/src/app/(payload)/api/mcp/route.ts
+++ b/src/app/(payload)/api/mcp/route.ts
@@ -28,5 +28,13 @@ export async function POST(req: NextRequest): Promise<Response> {
     body: bodyText,
   }) as unknown as NextRequest
 
-  return (postHandler as unknown as (req: NextRequest) => Promise<Response>)(freshReq)
+  // REST_POST handlers expect (request, { params: { slug } }) — the slug maps
+  // to the path segment after /api, so "mcp" routes to the /api/mcp endpoint.
+  type HandlerArgs = { params: Promise<{ slug: string[] }> }
+  const args: HandlerArgs = { params: Promise.resolve({ slug: ['mcp'] }) }
+
+  return (postHandler as unknown as (req: NextRequest, args: HandlerArgs) => Promise<Response>)(
+    freshReq,
+    args,
+  )
 }


### PR DESCRIPTION
Without the second args parameter, handlerBuilder throws TypeError: Cannot read properties of undefined (reading 'params').