### PR TITLE
fix: override req.body as Uint8Array to unblock mcp-handler req.json()

### DIFF
--- a/src/app/(payload)/api/mcp/route.ts
+++ b/src/app/(payload)/api/mcp/route.ts
@@ -13,20 +13,37 @@ const postHandler = REST_POST(config)
 /**
  * Dedicated handler for POST /api/mcp.
  *
- * Payload's generic [slug] handler wraps the NextRequest body in a new undici
- * Request. undici's req.json() cannot read a NextRequest ReadableStream and
- * hangs indefinitely, causing a 504. By reading the body here as text first
- * and creating a fresh Request with a plain string body, we hand Payload a
- * native undici-compatible body that mcp-handler can parse without hanging.
+ * The hang chain:
+ *   NextRequest body (ReadableStream)
+ *   → createPayloadRequest mutates the request object (body untouched)
+ *   → createRequestFromPayloadRequest builds new Request({ body: req.body })
+ *   → mcp-handler calls req.json() on that new Request
+ *   → undici cannot read a ReadableStream that came from a different undici
+ *     Request instance, so req.json() blocks forever → 504
+ *
+ * Fix: read the body here (works fine in a real Next.js route context), then
+ * override the .body getter on freshReq to return a Uint8Array.
+ * createRequestFromPayloadRequest passes req.body directly to new Request(),
+ * and undici handles ArrayBufferView bodies natively without any stream issue.
  */
 export async function POST(req: NextRequest): Promise<Response> {
   const bodyText = await req.text()
+  const bodyBytes = new TextEncoder().encode(bodyText)
 
   const freshReq = new Request(req.url, {
     method: 'POST',
     headers: req.headers,
     body: bodyText,
   }) as unknown as NextRequest
+
+  // Shadow the prototype .body getter with a plain Uint8Array value so that
+  // @payloadcms/plugin-mcp's createRequestFromPayloadRequest calls:
+  //   new Request(url, { body: Uint8Array, duplex: 'half' })
+  // instead of passing a ReadableStream that undici cannot consume.
+  Object.defineProperty(freshReq, 'body', {
+    get: () => bodyBytes,
+    configurable: true,
+  })
 
   // REST_POST handlers expect (request, { params: { slug } }) — the slug maps
   // to the path segment after /api, so "mcp" routes to the /api/mcp endpoint.


### PR DESCRIPTION
createRequestFromPayloadRequest passes req.body directly to new Request(). If body is a ReadableStream from another undici Request, req.json() hangs indefinitely. Overriding the body getter to return a Uint8Array gives undici an ArrayBufferView it can consume natively, resolving the 504.