### PR TITLE
fix: use ReadableStream for req.body override in MCP route

### DIFF
--- a/src/app/(payload)/api/mcp/route.ts
+++ b/src/app/(payload)/api/mcp/route.ts
@@ -24,7 +24,12 @@ export async function POST(req: NextRequest): Promise<Response> {
   }) as unknown as NextRequest
 
   Object.defineProperty(freshReq, 'body', {
-    get: () => bodyBytes,
+    get: () => new ReadableStream({
+      start(controller) {
+        controller.enqueue(bodyBytes)
+        controller.close()
+      },
+    }),
     configurable: true,
   })
 


### PR DESCRIPTION
Replaces Uint8Array body override with a proper ReadableStream so that undici's duplex: 'half' requirement is satisfied when mcp-handler calls req.json() on the re-wrapped request.