### PR TITLE
debug: numbered checkpoints + getPayload pre-init + Proxy body interc…

### DIFF
--- a/src/app/(payload)/api/mcp/route.ts
+++ b/src/app/(payload)/api/mcp/route.ts
@@ -1,5 +1,6 @@
 import config from '@payload-config'
 import { REST_POST } from '@payloadcms/next/routes'
+import { getPayload } from 'payload'
 import type { NextRequest } from 'next/server'
 
 export const dynamic = 'force-dynamic'
@@ -11,9 +12,24 @@ export async function POST(req: NextRequest): Promise<Response> {
   const t0 = Date.now()
   const log = (msg: string) => console.log(`[MCP +${Date.now() - t0}ms] ${msg}`)
 
-  log('POST entered')
-  const bodyText = await req.text()
-  log(`body read (${bodyText.length} bytes): ${bodyText.slice(0, 120)}`)
+  log('1 entered')
+
+  let bodyText: string
+  try {
+    bodyText = await req.text()
+    log(`2 body read (${bodyText.length} bytes)`)
+  } catch (err) {
+    log(`2 body read FAILED: ${String(err)}`)
+    return Response.json({ error: `body read failed: ${String(err)}` }, { status: 500 })
+  }
+
+  try {
+    await getPayload({ config })
+    log('3 payload ready')
+  } catch (err) {
+    log(`3 payload FAILED: ${String(err)}`)
+    return Response.json({ error: `payload init failed: ${String(err)}` }, { status: 500 })
+  }
 
   const bodyBytes = new TextEncoder().encode(bodyText)
 
@@ -23,36 +39,42 @@ export async function POST(req: NextRequest): Promise<Response> {
     body: bodyText,
   }) as unknown as NextRequest
 
-  Object.defineProperty(freshReq, 'body', {
-    get: () => new ReadableStream({
-      start(controller) {
-        controller.enqueue(bodyBytes)
-        controller.close()
-      },
-    }),
-    configurable: true,
-  })
+  // Proxy intercepts body access so each consumer gets a fresh ReadableStream,
+  // even if createPayloadRequest consumed the original body stream first.
+  const proxiedReq = new Proxy(freshReq, {
+    get(target, prop) {
+      if (prop === 'body') {
+        return new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(bodyBytes)
+            controller.close()
+          },
+        })
+      }
+      const value = Reflect.get(target, prop, target)
+      return typeof value === 'function' ? (value as CallableFunction).bind(target) : value
+    },
+  }) as unknown as NextRequest
 
   type HandlerArgs = { params: Promise<{ slug: string[] }> }
   const args: HandlerArgs = { params: Promise.resolve({ slug: ['mcp'] }) }
 
-  log('calling postHandler')
+  log('4 calling postHandler')
 
-  // Wrap in a 25 s timeout so we get a diagnostic 500 instead of a silent 504
   const TIMEOUT_MS = 25_000
   const result = await Promise.race([
     (postHandler as unknown as (req: NextRequest, args: HandlerArgs) => Promise<Response>)(
-      freshReq,
+      proxiedReq,
       args,
-    ).then((r) => { log(`postHandler resolved, status=${r.status}`); return r }),
+    ).then((r) => { log(`5 postHandler resolved status=${r.status}`); return r }),
     new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`MCP handler timeout after ${TIMEOUT_MS}ms`)), TIMEOUT_MS),
+      setTimeout(() => reject(new Error(`MCP timeout after ${TIMEOUT_MS}ms`)), TIMEOUT_MS),
     ),
   ]).catch((err: unknown) => {
-    log(`ERROR: ${String(err)}`)
+    log(`5 ERROR: ${String(err)}`)
     return Response.json({ error: String(err) }, { status: 500 })
   })
 
-  log('returning response')
+  log('6 returning')
   return result
 }


### PR DESCRIPTION
…eption

Adds numbered log checkpoints (1–6) to pinpoint the hang, wraps each phase in try-catch, pre-initialises Payload before calling postHandler, and switches from Object.defineProperty to a Proxy so body is intercepted even if undici uses internal slots.