### PR TITLE
docs: update roadmap, CLAUDE.md with current state and Figma MCP setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,8 @@ interface PageHeroProps {
 
 ## Recent Changes
 - **CMS migration**: Fully migrated from Sanity CMS to Payload CMS v3 (Local API, PostgreSQL via Neon, Vercel Blob for media)
+- **Payload security hardening**: Access control on all 15 collections, slug unique indexes + migration, Algolia lazy init, MCP plugin scoped (users/media excluded), singleton race condition fixed
+- **Performance optimization**: ISR revalidation on near-static pages, `unstable_cache` on creature layout + `fetchCharacterData`, parallelized slug lookups, `'use client'` removed from pure render components, creature cache auto-invalidates via `afterChange` hook
 - Interactive world map at /map using Leaflet + CRS.Simple with tile layer and GeoJSON region overlay
 - Custom creatures can be added to encounters via tabbed Codex/Custom creature selector
 - Creature Manager feature: custom creature creation, editing, roster management, CMS cloning, .creatura file import/export
@@ -500,6 +502,19 @@ src/app/components/
 ## Figma MCP Integration Rules
 
 These rules govern all Figma-to-code and code-to-Figma workflows.
+
+### Setup & Skills
+
+The Figma plugin (`figma@claude-plugins-official`) is installed globally and provides:
+- **MCP tools**: `get_design_context`, `get_metadata`, `get_screenshot`, `use_figma` (code execution), `authenticate`
+- **Skills**: `figma:figma-use`, `figma:figma-implement-design`, `figma:figma-generate-design`, `figma:figma-generate-library`, `figma:figma-create-design-system-rules`, `figma:figma-create-new-file`, `figma:figma-code-connect`
+
+**MANDATORY: Invoke `Skill("figma:figma-use")` before every `use_figma` call.** The skill provides critical API context. Without it, common errors occur (wrong method signatures, invalid enum values, async patterns).
+
+### Design System File
+
+Figma file: **"Atom Magic — Design System"** (key: `NOJ9ybTsaubW6DKkdTeA6u`)  
+Published as a shared library. All components are available to page capture files in the Atom Magic Figma project.
 
 ### Required Figma-to-Code Flow
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,9 +72,9 @@ RES dropped from high to 28. Root cause: CDN-cached Sanity calls replaced by liv
 - [x] **Cache `fetchCharacterData`** — 7 parallel DB queries per request; same result for all callers
 - [x] **Parallelize entry slug lookup** — 5 sequential DB queries replaced with `Promise.all`
 - [x] **Cache creature tools layout** — 500-doc query wrapped in `unstable_cache` with `creatures` tag
-- [x] **Constrain Neon pool for serverless** — `max: 1` added
+- [x] **Constrain Neon pool for serverless** — `max: 1` added then reverted (breaks parallel static generation at build time; serverless-only concern)
 - [x] **Remove `'use client'` from Entry/UnifiedEntry/PageHero** — pure render components; unnecessary client boundary removed
-- [ ] **Add `revalidateTag('creatures')` hook** — creature cache doesn't auto-invalidate on CMS save yet
+- [x] **Add `revalidateTag('creatures')` hook** — `src/payload/hooks/creatureCache.ts` fires on afterChange/afterDelete
 - [ ] **Lazy-load `styled-components` consumer** — runtime CSS-in-JS causing CLS
 - [ ] **Evaluate Neon HTTP driver** — eliminate TCP cold-start entirely
 
@@ -218,6 +218,7 @@ RES dropped from high to 28. Root cause: CDN-cached Sanity calls replaced by liv
 - [x] **Component tests** - Key interactive components (CoinSelector, CharacterRoster)
 - [x] **E2E tests with Playwright** - Critical user flows (create character, play Vorago game)
 - [ ] **Testing revisit** — After map, campaign management, and creature stat block features are complete, revisit component and E2E coverage for new flows
+- [ ] **Review and update all tests** — Audit existing Vitest unit tests and Playwright E2E tests for accuracy against current codebase; update stale assertions, add missing coverage for features added since initial test setup (creature manager, adventure log, campaign dashboard)
 
 ---
 


### PR DESCRIPTION
- ROADMAP: mark revalidateTag creatures hook complete; clarify max:1 revert
- ROADMAP: add test review/audit item under Testing Infrastructure
- CLAUDE.md: update Recent Changes with security hardening + perf work
- CLAUDE.md: expand Figma MCP section with skill names, mandatory figma-use rule, and design system file key so it's always available in context